### PR TITLE
replace 'good service' to 'no known disruptions' (#19)

### DIFF
--- a/src/components/ViewsToShow/DefaultView/ModalRow/helpers.tsx
+++ b/src/components/ViewsToShow/DefaultView/ModalRow/helpers.tsx
@@ -20,10 +20,10 @@ const disruptionIconToShow = (
   totalDisruptions: number | undefined,
   mode: DefaultModes
 ): DisruptionIconToShow => {
-  // If total modal disruption is 0 (good service)
+  // If total modal disruption is 0 (no known disruptions)
   let iconName = 'general-success';
   let disruptionIndicatorClass = 'wmnds-disruption-indicator-medium--success';
-  let htmlToShow = <strong>Good service</strong>;
+  let htmlToShow = <strong>No known disruptions</strong>;
 
   // If total modal  disruptions on mode is not 0 then it has disruptions
   if (totalDisruptions !== 0) {

--- a/src/components/shared/DisruptionIndicator/helpers.tsx
+++ b/src/components/shared/DisruptionIndicator/helpers.tsx
@@ -44,10 +44,10 @@ export const getSeverityVars = (
         class: 'severe',
       };
       break;
-    // Good service (low)
+    // No known disruptions (low)
     default:
       disruptionFlag = {
-        text: 'Good service',
+        text: 'No known disruptions',
         icon: 'success',
         class: 'success',
       };
@@ -58,8 +58,8 @@ export const getSeverityVars = (
 };
 
 export const disruptionTextElementToShow = (text: string, urlPath: string): JSX.Element => {
-  //  // If good service, display as strong. Otherwise display as link to that service
-  if (text.toLowerCase() !== 'good service')
+  //  // If no known disruptions, display as strong. Otherwise display as link to that service
+  if (text.toLowerCase() !== 'no known disruptions')
     return <Link href={`//disruptions.tfwm.org.uk/${urlPath}`}>{text}</Link>;
 
   return <strong>{text}</strong>;


### PR DESCRIPTION
Replace the 'good service' message with 'no known disruptions' 